### PR TITLE
protocol: Include whitespace when reading names

### DIFF
--- a/protocol.h
+++ b/protocol.h
@@ -23,7 +23,7 @@
 #include <libubox/avl.h>
 
 #define PR_NAMELEN 32
-#define PR_SCANFMT "%hhu %hu %32s\n"
+#define PR_SCANFMT "%hhu %hu %32[^\n]\n"
 
 
 struct protocol {


### PR DESCRIPTION
## In short

* Modify `PR_SCANFMT` to not skip whitespace in protocol names
  * Fixes [recently added protocols with spaces](https://github.com/jow-/nlbwmon/commit/e921ca0af9957d3cb05797acfb8bde4d7d2278e5)
  * Allows more flexibility in naming protocols

**NOTE:** As I have not (yet) set up an OpenWRT build environment, **this is not tested.**

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | User-facing fix for default protocols, matches expectations
Risk | ★★☆ *2/3* | Untested, could impact existing protocol name configurations
Intrusiveness | ★☆☆ *1/3* | Small set of changes, shouldn't interfere with other pull requests

## Details
Include whitespace when reading protocol names via fscanf() by including all characters except for a newline, still limited to 32 bytes.

This fixes [the new protocols added in a recent commit which include spaces in the names](https://github.com/jow-/nlbwmon/commit/e921ca0af9957d3cb05797acfb8bde4d7d2278e5), and it allows for more flexibility in general.

### References
* https://stackoverflow.com/questions/1950057/can-fscanf-read-whitespace
* http://www.cplusplus.com/reference/cstdio/fscanf/

**NOTE:**  This change has not been personally tested and may need further modifications.