### PR TITLE
nlbwmon: fix db cleanup

### DIFF
--- a/nlbwmon.c
+++ b/nlbwmon.c
@@ -134,8 +134,10 @@ handle_refresh(struct uloop_timeout *tm)
 	err = database_archive(gdbh);
 
 	/* database successfully wrapped around and triggered a ct dump */
-	if (err == -ESTALE)
+	if (err == -ESTALE) {
+		database_cleanup();
 		return;
+	}
 
 	/* fatal error during database archiving */
 	if (err != 0) {


### PR DESCRIPTION
@jow- The database will only be cleaned up when the daemon is restarted. With
this change, each refresh of the database checks whether the artifacts
should be cleaned up from the past database. Thus, no more than
configured are kept.

This fixes https://github.com/openwrt/packages/issues/14297