### PR TITLE
Only write database a second time after merge.

### DIFF
--- a/nlbwmon.c
+++ b/nlbwmon.c
@@ -86,9 +86,10 @@ static void save_persistent(uint32_t timestamp)
 			fprintf(stderr, "Unable to load existing database: %s\n",
 			        strerror(-err));
 		}
+		else {
+			err = database_save(gdbh, opt.db.directory, timestamp, opt.db.compress);
+		}
 	}
-
-	err = database_save(gdbh, opt.db.directory, timestamp, opt.db.compress);
 
 	if (err) {
 		fprintf(stderr, "Unable to save database: %s\n",


### PR DESCRIPTION
Signed-off-by: Chad Fraleigh <chadf@triularity.org>

The database is currently always saved twice. Change to only save a second time when merging with existing file.