### PR TITLE
add support for minute interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ storage requirements.</dd>
 <dt>-c command</dt>
 <dd>Specify a command.  Current commands are: show, json, csv, list, commit.  See below for more information about commands.</dd>
 
-<dt>-p /path/to/procol-database</dt>
+<dt>-p /path/to/protocol-database</dt>
 <dd>Protocol description file, used to distinguish traffic streams by IP protocol number and port.</dd>
 
 <dt>-g col[,col]</dt>

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ Each time the conntrack entries are polled, their counters are reset (zero-on-re
 <dd>Accounting period interval.  May be either in the format YYYY-MM-DD/NN,
 to start a new accounting period exactly every NN days, beginning at
 the given date, or a number specifiying the day of month at which to
-start the next accounting period.  For example:</dd>
+start the next accounting period, or in the format MMm for MM minutes.  For example:</dd>
 </dl>
 
 ```
 2017-01-17/14   # every 14 days, starting Jan 17, 2017
 -2              # second to the last day of the month, e.g. 30th in March
 1               # first day of the month (default)
+60m             # every hour
 ```
 
 <dl>
@@ -87,7 +88,7 @@ storage requirements.</dd>
 <dt>-o col[,col]</dt>
 <dd>Order output by the specified column.  Prefix column with a - to invert order.</dd>
 
-<dt>-t YYYY-MM-DD</dt>
+<dt>-t YYYY-MM-DD|timestamp</dt>
 <dd>Read data from the specified database, instead of the active database.  Use the list command to view available databases.</dd>
 
 <dt>-n</dt>
@@ -101,6 +102,9 @@ storage requirements.</dd>
 
 <dt>-e char</dt>
 <dd>Specify the escape character when using CSV format.  If no argument is provided, an empty string is assumed.  Currently only applies to CSV format.</dd>
+
+<dt>-G count</dt>
+<dd>Number of database generations to retrieve.  Data from databases are summed. Note: connection is counted in each database, so connection spanning two intervals is counted twice.</dd>
 </dl>
 
 

--- a/client.c
+++ b/client.c
@@ -297,14 +297,14 @@ handle_show(void)
 		printf("%c Fam ", columns[FAMILY]);
 
 	if (columns[HOST]) {
-		printf("         %c Host (    MAC )  ", columns[HOST]);
+		printf("                                 %c Host (    MAC )  ", columns[HOST]);
 	}
 	else {
 		if (columns[MAC])
 			printf("            %c MAC  ", columns[MAC]);
 
 		if (columns[IP])
-			printf("           %c IP  ", columns[IP]);
+			printf("                                   %c IP  ", columns[IP]);
 	}
 
 	if (columns[LAYER7]) {
@@ -328,7 +328,7 @@ handle_show(void)
 			printf("IPv%d  ", rec->family == AF_INET ? 4 : 6);
 
 		if (columns[HOST]) {
-			printf("%15s (%02x:%02x:%02x)  ",
+			printf("%39s (%02x:%02x:%02x)  ",
 			       format_ipaddr(rec->family, &rec->src_addr),
 			       rec->src_mac.ea.ether_addr_octet[3],
 			       rec->src_mac.ea.ether_addr_octet[4],
@@ -339,7 +339,7 @@ handle_show(void)
 				printf("%17s  ", format_macaddr(&rec->src_mac.ea));
 
 			if (columns[IP])
-				printf("%15s  ", format_ipaddr(rec->family, &rec->src_addr));
+				printf("%39s  ", format_ipaddr(rec->family, &rec->src_addr));
 		}
 
 		if (columns[LAYER7]) {

--- a/client.c
+++ b/client.c
@@ -621,8 +621,8 @@ handle_list(void)
 		return -errno;
 	}
 
-	uint8_t interval_type;
-	if (recv(ctrl_socket, &interval_type, sizeof(interval_type), 0) <= 0) {
+	struct interval interval;
+	if (recv(ctrl_socket, &interval, sizeof(interval), 0) <= 0) {
 		close(ctrl_socket);
 		return 0;
 	}
@@ -632,7 +632,7 @@ handle_list(void)
 		         sizeof(client_opt.timestamp), 0) <= 0)
 			break;
 
-		if (interval_type == MINUTE) {
+		if (interval.type == MINUTE) {
 			time_t t = client_opt.timestamp * 60;
 			struct tm *timeinfo = localtime (&t);
 			char timestr[50];

--- a/database.c
+++ b/database.c
@@ -563,7 +563,7 @@ database_load(struct dbhandle *h, const char *path, uint32_t timestamp)
 int
 database_cleanup(void)
 {
-	uint32_t timestamp, num;
+	uint32_t timestamp, num, safe_low;
 	struct dirent *entry;
 	char *e, path[256];
 	DIR *d;
@@ -579,6 +579,8 @@ database_cleanup(void)
 	errno = 0;
 	timestamp = interval_timestamp(&opt.archive_interval, -opt.db.generations);
 
+    safe_low = opt.archive_interval.type == MINUTE ? 1704067200 / 60 : 20000101;
+
 	while ((entry = readdir(d)) != NULL) {
 		if (entry->d_type != DT_REG)
 			continue;
@@ -591,7 +593,7 @@ database_cleanup(void)
 		if (strcmp(e, ".db") != 0 && strcmp(e, ".db.gz") != 0)
 			continue;
 
-		if (num < 20000101 || num > timestamp)
+		if (num < safe_low || num > timestamp)
 			continue;
 
 		snprintf(path, sizeof(path), "%s/%u%s", opt.db.directory, num, e);

--- a/database.c
+++ b/database.c
@@ -618,6 +618,8 @@ database_archive(struct dbhandle *h)
 		if (err)
 			return err;
 
+		database_cleanup();
+
 		/* lazily reset database, don't (re)alloc */
 		h->off = 0;
 		h->db->entries = 0;

--- a/database.c
+++ b/database.c
@@ -454,6 +454,7 @@ database_restore_gzip(struct dbhandle *h, const char *path, uint32_t timestamp)
 
 	if (h) {
 		h->pristine = false;
+		h->db->timestamp = htobe32(timestamp);
 
 		for (i = 0; i < entries; i++) {
 			if (gzread(gz, &rec, db_recsize) != db_recsize) {

--- a/nlbwmon.c
+++ b/nlbwmon.c
@@ -96,9 +96,10 @@ static void save_persistent(uint32_t timestamp)
 			fprintf(stderr, "Unable to load existing database: %s\n",
 			        strerror(-err));
 		}
+		else {
+			err = database_save(gdbh, opt.db.directory, timestamp, opt.db.compress);
+		}
 	}
-
-	err = database_save(gdbh, opt.db.directory, timestamp, opt.db.compress);
 
 	if (err) {
 		fprintf(stderr, "Unable to save database: %s\n",

--- a/socket.c
+++ b/socket.c
@@ -135,7 +135,7 @@ handle_list(int sock, const char *arg)
 	int delta = 0;
 	uint32_t timestamp;
 
-	if (send(sock, &opt.archive_interval.type, sizeof(opt.archive_interval.type), 0) != sizeof(opt.archive_interval.type))
+	if (send(sock, &opt.archive_interval, sizeof(opt.archive_interval), 0) != sizeof(opt.archive_interval))
 		return -errno;
 
 	while (true) {

--- a/socket.c
+++ b/socket.c
@@ -120,6 +120,9 @@ handle_list(int sock, const char *arg)
 	int delta = 0;
 	uint32_t timestamp;
 
+	if (send(sock, &opt.archive_interval.type, sizeof(opt.archive_interval.type), 0) != sizeof(opt.archive_interval.type))
+		return -errno;
+
 	while (true) {
 		timestamp = interval_timestamp(&opt.archive_interval, delta--);
 		err = database_load(NULL, opt.db.directory, timestamp);

--- a/socket.c
+++ b/socket.c
@@ -153,7 +153,7 @@ handle_list(int sock, const char *arg)
 			break;
 		}
 
-		if (send(sock, &timestamp, sizeof(timestamp), 0) != sizeof(timestamp))
+		if (send_data(sock, &timestamp, sizeof(timestamp)) != sizeof(timestamp))
 			return -errno;
 	}
 

--- a/socket.c
+++ b/socket.c
@@ -129,6 +129,9 @@ handle_list(int sock, const char *arg)
 				fprintf(stderr, "Corrupted database detected: %d (%s)\n",
 				        timestamp, strerror(-err));
 
+			if (opt.db.generations && delta > -opt.db.generations)
+				continue;
+
 			break;
 		}
 

--- a/timing.c
+++ b/timing.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <endian.h>
 #include <errno.h>
+#include <string.h>
 
 #include "timing.h"
 
@@ -134,6 +135,14 @@ interval_timestamp_monthly(const struct interval *intv, int offset)
 }
 
 static int
+interval_timestamp_minute(const struct interval *intv, int offset)
+{
+	time_t now = time(NULL);
+	uint32_t ts = (uint32_t) (now / 60);
+	return ts + offset;
+}
+
+static int
 interval_timestamp_fixed(const struct interval *intv, int offset)
 {
 	time_t now, base;
@@ -191,6 +200,12 @@ interval_pton(const char *spec, struct interval *intv)
 
 		return 0;
 	}
+	if (!strcmp(spec, "m")) {
+		intv->type  = MINUTE;
+		intv->value = 0;
+		intv->base  = 0;
+		return 0;
+	}
 
 	value = strtol(spec, &e, 10);
 
@@ -223,6 +238,10 @@ interval_ntop(const struct interval *intv, char *spec, size_t len)
 	case MONTHLY:
 		snprintf(spec, len, "%d", (int32_t)be32toh(intv->value));
 		break;
+
+	case MINUTE:
+		snprintf(spec, len, "m");
+		break;
 	}
 }
 
@@ -236,6 +255,9 @@ interval_timestamp(const struct interval *intv, int offset)
 
 	case MONTHLY:
 		return interval_timestamp_monthly(intv, offset);
+
+	case MINUTE:
+		return interval_timestamp_minute(intv, offset);
 	}
 
 	return -EINVAL;

--- a/timing.c
+++ b/timing.c
@@ -138,8 +138,8 @@ static int
 interval_timestamp_minute(const struct interval *intv, int offset)
 {
 	time_t now = time(NULL);
-	uint32_t ts = (uint32_t) (now / 60);
-	return ts + offset;
+	uint32_t ts = (uint32_t) (intv->value * (now / (60 * intv->value)));
+	return ts + (offset * intv->value);
 }
 
 static int
@@ -200,9 +200,9 @@ interval_pton(const char *spec, struct interval *intv)
 
 		return 0;
 	}
-	if (!strcmp(spec, "m")) {
+	if (sscanf(spec, "%um", &value) == 1) {
 		intv->type  = MINUTE;
-		intv->value = 0;
+		intv->value = value;
 		intv->base  = 0;
 		return 0;
 	}
@@ -240,7 +240,7 @@ interval_ntop(const struct interval *intv, char *spec, size_t len)
 		break;
 
 	case MINUTE:
-		snprintf(spec, len, "m");
+		snprintf(spec, len, "%um", (int32_t)be32toh(intv->value));
 		break;
 	}
 }

--- a/timing.h
+++ b/timing.h
@@ -25,6 +25,7 @@
 enum interval_type {
 	MONTHLY = 1,
 	FIXED   = 2,
+	MINUTE  = 3
 };
 
 struct interval {


### PR DESCRIPTION
This add support for minute interval. timestamp is formatted as `time_t / 60` in both file names, client -t parameter etc. 
- client list command will list all databases even if there is a hole in the sequence
- client will detect interval format automatically
- client is able to retrieve multiple databases and merge them (sum data)
- fix for cleaning up databases regularly and only write database a second time after merge were included