### PR TITLE
client.c: increase buffer size

### DIFF
--- a/client.c
+++ b/client.c
@@ -147,7 +147,7 @@ format_num(uint64_t n)
 {
 	uint64_t e = 0x1000000000000000;
 	const char *unit = "EPTGMK";
-	static char buf[10];
+	static char buf[40];
 
 	n = be64toh(n);
 


### PR DESCRIPTION
Fix GCC 15.1 build failure due to PRIu64 expanding to "lu" on 64-bit systems, so the format string becomes "%4lu.%02lu %c". GCC is warning that a 64-bit number could potentially require up to 20 digits, plus the decimal point, two more digits, space, and character - potentially exceeding the 10-byte buffer.